### PR TITLE
docs: add link to webstorm prettier docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ You may also want to enable "Format on Save" in `.vscode/settings.json`:
 }
 ```
 
+### WebStorm
+
+Follow the instructions in the [WebStorm docs](https://www.jetbrains.com/help/webstorm/prettier.html).
+
 ## How to adjust tab width
 
 We use tabs, not spaces, for indentation because of their accessibility benefits. Users are then

--- a/README.md
+++ b/README.md
@@ -112,7 +112,29 @@ You may also want to enable "Format on Save" in `.vscode/settings.json`:
 
 ### WebStorm
 
-Follow the instructions in the [WebStorm docs](https://www.jetbrains.com/help/webstorm/prettier.html).
+The Webstorm default installation should already contain the [JetBrains Prettier plugin](https://plugins.jetbrains.com/plugin/10456-prettier).
+
+If you install this acdh config via the embedded terminal (<kbd>Alt</kbd>+<kbd>F12</kbd>) as suggested [here](#how-to-install) the plugin should configure itself automagically. Alternately you may adjust it's settings via the *Settings/Preferences* dialog (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>), under *Languages & Frameworks | JavaScript | Prettier* . It's  highly recommended to check both *On code reformat* and *On Save* there as well. (See [this section](#how-to-auto-format-with-git-hooks) for alternate/additional automation possibilities).
+
+By default the set [glob pattern](https://github.com/isaacs/node-glob#glob-primer) will only match JavaScript, TypeScript, JSX and TSX files. Depending on your stack it's recommended to extend it to
+
+```glob
+{**/*,*}.{js,json,ts,jsx,tsx,vue}
+```
+To ship this config with your project, commit/include the `prettier.xml` in your `.idea` config folder:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myRunOnSave" value="true" />
+    <option name="myRunOnReformat" value="true" />
+    <option name="myFilesPattern" value="{**/*,*}.{js,json,ts,jsx,tsx,vue}" />
+  </component>
+</project>
+```
+
+For more detailed instructions see the WebStorm docs on [Prettier](https://www.jetbrains.com/help/webstorm/prettier.html) and [Vue.js formatting](https://www.jetbrains.com/help/webstorm/vue-js.html#ws_vue_formatting)
 
 ## How to adjust tab width
 


### PR DESCRIPTION
this adds a link to the webstorm docs to the editor integrations section.