### PR TITLE
fix: treat whitespace as insignificant in .vue files

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ const config = {
 	tabWidth: 2,
 	trailingComma: "all",
 	useTabs: true,
+	overrides: [
+		{
+			files: ["*.vue"],
+			options: {
+				htmlWhitespaceSensitivity: "ignore",
+			},
+		},
+	],
 };
 
 module.exports = config;


### PR DESCRIPTION
this treats whitespace as insignificant in .vue files. see https://prettier.io/docs/en/options.html#html-whitespace-sensitivity