### PR TITLE
fix: provide types to allow importing config for programmatic use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import type { Config } from "prettier";
+
+declare const config: Config;
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
 	"name": "@acdh-oeaw/prettier-config",
 	"version": "0.1.0",
 	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
+	},
 	"main": "index.js",
+	"types": "index.d.ts",
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
+	"packageManager": "pnpm@7.21.0",
 	"scripts": {
 		"changeset:add": "changeset add",
 		"changeset:status": "changeset status --verbose",
@@ -19,6 +28,7 @@
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.4.8",
 		"@changesets/cli": "^2.26.0",
+		"@types/prettier": "^2.7.2",
 		"lint-staged": "^13.1.0",
 		"prettier": "^2.8.0",
 		"simple-git-hooks": "^2.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   "@changesets/changelog-github": ^0.4.8
   "@changesets/cli": ^2.26.0
+  "@types/prettier": ^2.7.2
   lint-staged: ^13.1.0
   prettier: ^2.8.0
   simple-git-hooks: ^2.8.1
@@ -10,6 +11,7 @@ specifiers:
 devDependencies:
   "@changesets/changelog-github": 0.4.8
   "@changesets/cli": 2.26.0
+  "@types/prettier": 2.7.2
   lint-staged: 13.1.0
   prettier: 2.8.0
   simple-git-hooks: 2.8.1
@@ -398,6 +400,13 @@ packages:
     resolution:
       {
         integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==,
+      }
+    dev: true
+
+  /@types/prettier/2.7.2:
+    resolution:
+      {
+        integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==,
       }
     dev: true
 


### PR DESCRIPTION
- provides types to allow importing this prettier config in ts files for programmatic use in scripts.
- also (unrelated) adds publish config to package.json