### PR TITLE
fix: avoid formatting pnpm lock file

### DIFF
--- a/.changeset/tall-humans-kiss.md
+++ b/.changeset/tall-humans-kiss.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/prettier-config": patch
+---
+
+avoid formatting pnpm-lock.yaml

--- a/index.js
+++ b/index.js
@@ -5,11 +5,23 @@ const config = {
 	proseWrap: "always",
 	semi: true,
 	singleQuote: false,
-	// Used to calculate print width.
+	/** Used to calculate print width. */
 	tabWidth: 2,
 	trailingComma: "all",
 	useTabs: true,
 	overrides: [
+		/**
+		 * Currently it is not possible to set ignore patterns via config,
+		 * or set more than one ignore file (e.g. `.gitignore` and `prettierignore`).
+		 *
+		 * This workaround avoids auto-formatting `pnpm`'s lock file.
+		 */
+		{
+			files: "pnpm-lock.yaml",
+			options: {
+				rangeEnd: 0,
+			},
+		},
 		{
 			files: ["*.vue"],
 			options: {


### PR DESCRIPTION
unfortunately, prettier currently does not allow specifying ignore patterns via config, or setting multiple prettier ignore file paths (in our case in addition to `.gitignore`).

this means we currently get formatting errors on every `pnpm install` for `pnpm-lock.yaml`.

this works around that issue until there is a proper fix upstream.